### PR TITLE
Support for Sketch document version 120

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-exports.version = 119
+exports.version = 120
 exports.document = require('./dist/document.schema.json')
 exports.fileFormat = require('./dist/file-format.schema.json')
 exports.meta = require('./dist/meta.schema.json')

--- a/schema/enums/inferred-layout-anchor.schema.yaml
+++ b/schema/enums/inferred-layout-anchor.schema.yaml
@@ -1,0 +1,11 @@
+title: Inferred Layout Anchor
+description: Enumeration of the anchor types for inferred (aka smart) layout
+type: integer
+enum:
+  - 0
+  - 1
+  - 2
+enumDescriptions:
+  - Min
+  - Middle
+  - Max

--- a/schema/enums/inferred-layout-axis.schema.yaml
+++ b/schema/enums/inferred-layout-axis.schema.yaml
@@ -1,0 +1,11 @@
+title: Inferred Layout Axis
+description: Enumeration of the axis types for inferred (aka smart) layout
+type: integer
+enum:
+  - 0
+  - 1
+  - 2
+enumDescriptions:
+  - None
+  - Horizontal
+  - Vertical

--- a/schema/layers/abstract-group.schema.yaml
+++ b/schema/layers/abstract-group.schema.yaml
@@ -7,12 +7,12 @@ allOf:
     optional:
       - groupLayout
     properties:
-      hasClickThrough:
-        type: boolean
-        description: TODO
-      groupLayout: { $ref: ../objects/freeform-group-layout.schema.yaml }
+      hasClickThrough: { type: boolean }
+      groupLayout:
+        oneOf:
+          - { $ref: ../objects/freeform-group-layout.schema.yaml }
+          - { $ref: ../objects/inferred-group-layout.schema.yaml }
       layers:
-        description: TODO
         type: array
         items:
           oneOf:

--- a/schema/layers/abstract-layer.schema.yaml
+++ b/schema/layers/abstract-layer.schema.yaml
@@ -35,3 +35,4 @@ properties:
     type: object
     additionalProperties: true
   style: { $ref: ../objects/style.schema.yaml }
+  maintainScrollPosition: { type: boolean }

--- a/schema/layers/rectangle.schema.yaml
+++ b/schema/layers/rectangle.schema.yaml
@@ -9,3 +9,4 @@ allOf:
       _class: { const: rectangle }
       fixedRadius: { type: number }
       hasConvertedToNewRoundCorners: { type: boolean }
+      needsConvertionToNewRoundCorners: { type: boolean }

--- a/schema/meta.schema.yaml
+++ b/schema/meta.schema.yaml
@@ -22,7 +22,7 @@ properties:
                 type: object
                 properties:
                   name: { type: string }
-  version: { const: 119 }
+  version: { const: 120 }
   fonts:
     type: array
     items: { type: string }
@@ -46,11 +46,5 @@ properties:
   appVersion:
     type: string
     enum:
-      - '55.2'
-      - '56'
-      - '56.1'
-      - '56.2'
-      - '56.3'
-      - '57'
-      - '57.1'
+      - '58'
   build: { type: integer }

--- a/schema/objects/asset-collection.schema.yaml
+++ b/schema/objects/asset-collection.schema.yaml
@@ -3,7 +3,6 @@ description: Collection of global document objects
 type: object
 optional:
   - imageCollection
-  - exportPresets
 properties:
   _class: { const: assetCollection }
   imageCollection: { $ref: ./image-collection.schema.yaml }

--- a/schema/objects/border.schema.yaml
+++ b/schema/objects/border.schema.yaml
@@ -1,9 +1,6 @@
 title: Border
 description: Defines a border style
 type: object
-optional:
-  - contextSettings
-  - gradient
 properties:
   _class: { const: border }
   isEnabled: { type: boolean }

--- a/schema/objects/fill.schema.yaml
+++ b/schema/objects/fill.schema.yaml
@@ -1,9 +1,6 @@
 title: Fill
 description: Defines a fill style
 type: object
-optional:
-  - contextSettings
-  - gradient
 properties:
   _class: { const: fill }
   isEnabled: { type: boolean }

--- a/schema/objects/inferred-group-layout.schema.yaml
+++ b/schema/objects/inferred-group-layout.schema.yaml
@@ -1,0 +1,7 @@
+title: Inferred Group Layout
+description: Inferred group layout defines smart layout options
+type: object
+properties:
+  _class: { const: MSImmutableInferredGroupLayout }
+  axis: { $ref: ../enums/inferred-layout-axis.schema.yaml }
+  layoutAnchor: { $ref: ../enums/inferred-layout-anchor.schema.yaml }

--- a/schema/objects/style.schema.yaml
+++ b/schema/objects/style.schema.yaml
@@ -4,13 +4,10 @@ type: object
 optional:
   - blur
   - borders
-  - borderOptions
   - contextSettings
   - fills
   - shadows
   - textStyle
-  - colorControls
-  - innerShadows
 properties:
   _class: { const: style }
   borders:

--- a/scripts/integration-test.mjs
+++ b/scripts/integration-test.mjs
@@ -51,7 +51,9 @@ const integrationTest = () => {
     errors.push(...validate(metaValidator, file.data.meta, 'Meta'))
     errors.push(...validate(userValidator, file.data.user, 'User'))
     for (const page of file.data.pages) {
-      errors.push(...validate(pageValidator, page, 'Page'))
+      errors.push(
+        ...validate(pageValidator, page, `Page "${page.do_objectID}"`),
+      )
     }
   }
 


### PR DESCRIPTION
Support for smart layout settings and numerous other schema changes around objects with default
values now being persisted to JSON rather than being omitted.

BREAKING CHANGE: The schemas will no longer validate Sketch files for document versions less than 120

Closes #15 