### PR TITLE
chore: mv sketch-file-format-x to devD

### DIFF
--- a/packages/file-format-ts/package.json
+++ b/packages/file-format-ts/package.json
@@ -18,12 +18,11 @@
     "typescript",
     "types"
   ],
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@sketch-hq/sketch-file-format-1": "npm:@sketch-hq/sketch-file-format@1.1.7",
     "@sketch-hq/sketch-file-format-2": "npm:@sketch-hq/sketch-file-format@2.0.3",
-    "@sketch-hq/sketch-file-format": "5.2.3"
-  },
-  "devDependencies": {
+    "@sketch-hq/sketch-file-format": "5.2.3",
     "@types/humps": "2.0.0",
     "humps": "2.0.1",
     "ts-node": "9.1.1"


### PR DESCRIPTION
I found some npm mirrors and private regsitry like [tnpm](https://web.npm.alibaba-inc.com/#!) do not support the multi version grammar like:
`"@sketch-hq/sketch-file-format-1": "npm:@sketch-hq/sketch-file-format@1.1.7",`

But anyway, I believe these sketch-file-format-x should be devDependencies cuz they are only used in scripts.