### PR TITLE
Include type declarations

### DIFF
--- a/.changeset/strange-stingrays-tease.md
+++ b/.changeset/strange-stingrays-tease.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file-format-ts': patch
+---
+
+Re-include type declarations

--- a/packages/file-format-ts/tsconfig.esm.json
+++ b/packages/file-format-ts/tsconfig.esm.json
@@ -4,6 +4,7 @@
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "dist/esm",
-    "module": "ESNext"
+    "module": "ESNext",
+    "declaration": true
   }
 }

--- a/packages/file-format-ts/tsconfig.json
+++ b/packages/file-format-ts/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["index.ts"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "declaration": true
   }
 }


### PR DESCRIPTION
With the recent refactor of the `tsconfig.json` files, it looks like we accidentally dropped [`"declarations": true`](https://github.com/sketch-hq/sketch-file-format-ts/blob/main/tsconfig.json#L3). This pull request explicitly sets it for both CommonJS and ES modules.