### PR TITLE
Move zip related devDependencies to dependencies

### DIFF
--- a/.changeset/many-maps-wash.md
+++ b/.changeset/many-maps-wash.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file': patch
+---
+
+Include missing dependencies

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -19,10 +19,12 @@
     "test": "jest",
     "format-check": "prettier --check **.{ts,md} --ignore-path ../../.prettierignore"
   },
-  "devDependencies": {
-    "@sketch-hq/sketch-file-format-ts": "6.0.2",
-    "@types/adm-zip": "0.4.34",
+  "dependencies": {
     "adm-zip": "0.5.5",
-    "node-stream-zip": "1.13.3"
+    "node-stream-zip": "1.13.3",
+    "@sketch-hq/sketch-file-format-ts": "6.0.2"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "0.4.34"
   }
 }


### PR DESCRIPTION
Both `adm-zip` and `StreamZip` must be defined as part of the production bundle. To be picked up by npm/yarn during installation of the `sketch-file` package, they must be moved to `dependencies`.