### PR TITLE
Remove unused fonts metadata

### DIFF
--- a/.changeset/fluffy-geese-lie.md
+++ b/.changeset/fluffy-geese-lie.md
@@ -1,0 +1,6 @@
+---
+'@sketch-hq/sketch-file-format': patch
+'@sketch-hq/sketch-file-format-ts': patch
+---
+
+Removed fonts property from meta.json

--- a/packages/file-format/schema/meta.schema.yaml
+++ b/packages/file-format/schema/meta.schema.yaml
@@ -43,9 +43,6 @@ properties:
       - 134
       - 135
       - 136
-  fonts:
-    type: array
-    items: { type: string }
   compatibilityVersion: { const: 99 }
   coeditCompatibilityVersion: { type: number }
   app: { $ref: ./enums/bundle-id.schema.yaml }

--- a/packages/file/src/__tests__/file.test.ts
+++ b/packages/file/src/__tests__/file.test.ts
@@ -95,7 +95,6 @@ describe('toFile', () => {
       autosaved: 0,
       build: 0,
       compatibilityVersion: 99,
-      fonts: [''],
       variant: 'TESTING',
       created: {
         commit: '6896e2bfdb0a2a03f745e4054a8c5fc58565f9f1',


### PR DESCRIPTION
The fonts attribute previously used to determine missing fonts has been removed.