### PR TITLE
String length bug

### DIFF
--- a/.changeset/great-waves-drive.md
+++ b/.changeset/great-waves-drive.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file': minor
+---
+
+Fix issue with using `String.length` to calculate bytesize for unicode strings

--- a/packages/file/src/file.ts
+++ b/packages/file/src/file.ts
@@ -88,7 +88,7 @@ const toFile = async (obj: SketchFile): Promise<void> => {
       const p = JSON.stringify(obj.contents.workspace[key])
       sketch.addFile(
         path.join('workspace', `${key}.json`),
-        Buffer.alloc(p.length, p),
+        Buffer.alloc(Buffer.byteLength(p), p),
         `workspace data for: ${key}`,
       )
     })
@@ -105,7 +105,7 @@ const toFile = async (obj: SketchFile): Promise<void> => {
     Object.entries(data).map(([key, val]) => {
       sketch.addFile(
         `${key}.json`,
-        Buffer.alloc(val.length, val),
+        Buffer.alloc(Buffer.byteLength(val), val),
         `${key} data`,
       )
     })

--- a/packages/file/src/file.ts
+++ b/packages/file/src/file.ts
@@ -68,10 +68,6 @@ const toFile = async (obj: SketchFile): Promise<void> => {
       const p = JSON.stringify(page)
       sketch.addFile(
         path.join('pages', `${page.do_objectID}.json`),
-        // When using double-byte characters (like •), the length of the string
-        // won't match the bytes needed to store the string data on disk.
-        // So, we'd better use a proper method to find the length, like `Buffer.byteLength(p)`,
-        // instead of the more brittle `p.length` we were using.
         Buffer.alloc(Buffer.byteLength(p), p),
         `page data for: ${page.name}`,
       )


### PR DESCRIPTION
When using double-byte characters (like •), the length of the string won't match the bytes needed to store the string data on disk. So, we'd better use a proper method to find the length, like `Buffer.byteLength(p)`, instead of the more brittle `p.length` we were using.

This resulted in data loss when saving documents, rendering processed documents unreadable by Sketch.