### PR TITLE
Replace presetDictionary with prototypeViewport on Artboard

### DIFF
--- a/.changeset/sour-emus-jam.md
+++ b/.changeset/sour-emus-jam.md
@@ -3,6 +3,5 @@
 '@sketch-hq/sketch-file-format-ts': minor
 ---
 
-Artboards now contain a prototypeViewport object to describe the assigned
-viewport for prototypes, replacing the loosely typed presetDictionary attribute.
-FlowConnection now also contains an automatic destination option.
+- Artboards now contain a `prototypeViewport` attribute with a `PrototypeViewport` object to describe the associated viewport for prototypes, replacing the untyped presetDictionary attribute.
+- FlowConnection now contains an automatic destination option.

--- a/.changeset/sour-emus-jam.md
+++ b/.changeset/sour-emus-jam.md
@@ -3,5 +3,6 @@
 '@sketch-hq/sketch-file-format-ts': minor
 ---
 
+- Add `isTemplate` attribute to Layer to mark it as template for insertion of copies elsewhere.
 - Artboards now contain a `prototypeViewport` attribute with a `PrototypeViewport` object to describe the associated viewport for prototypes, replacing the untyped presetDictionary attribute.
 - FlowConnection now contains an automatic destination option.

--- a/.changeset/sour-emus-jam.md
+++ b/.changeset/sour-emus-jam.md
@@ -1,0 +1,8 @@
+---
+'@sketch-hq/sketch-file-format': minor
+'@sketch-hq/sketch-file-format-ts': minor
+---
+
+Artboards now contain a prototypeViewport object to describe the assigned
+viewport for prototypes, replacing the loosely typed presetDictionary attribute.
+FlowConnection now also contains an automatic destination option.

--- a/packages/file-format/schema/layers/abstract-layer.schema.yaml
+++ b/packages/file-format/schema/layers/abstract-layer.schema.yaml
@@ -19,6 +19,7 @@ properties:
   isFlippedHorizontal: { type: boolean }
   isFlippedVertical: { type: boolean }
   isLocked: { type: boolean }
+  isTemplate: { type: boolean }
   isVisible: { type: boolean }
   layerListExpandedType: { $ref: ../enums/layer-list-expanded.schema.yaml }
   name: { type: string }

--- a/packages/file-format/schema/layers/artboard.schema.yaml
+++ b/packages/file-format/schema/layers/artboard.schema.yaml
@@ -9,7 +9,7 @@ allOf:
   # inherit directly for simplicity of inheritence tree.
   - type: object
     optional:
-      - presetDictionary
+      - prototypeViewport
     properties:
       _class: { const: artboard }
       backgroundColor: { $ref: ../objects/color.schema.yaml }
@@ -17,7 +17,7 @@ allOf:
       includeBackgroundColorInExport: { type: boolean }
       isFlowHome: { type: boolean }
       resizesContent: { type: boolean }
-      presetDictionary: { type: object }
+      prototypeViewport: { $ref: ../objects/prototype-viewport.schema.yaml }
       layers:
         type: array
         items:

--- a/packages/file-format/schema/objects/flow-connection.schema.yaml
+++ b/packages/file-format/schema/objects/flow-connection.schema.yaml
@@ -9,5 +9,6 @@ properties:
     oneOf:
       - { $ref: ../utils/uuid.schema.yaml }
       - { const: back }
+      - { const: automatic }
   animationType: { $ref: ../enums/animation-type.schema.yaml }
   maintainScrollPosition: { type: boolean }

--- a/packages/file-format/schema/objects/prototype-viewport.schema.yaml
+++ b/packages/file-format/schema/objects/prototype-viewport.schema.yaml
@@ -10,5 +10,5 @@ properties:
   _class: { const: MSImmutablePrototypeViewport }
   name: { type: string }
   size: { $ref: ../utils/size-string.schema.yaml }
-  templateID: { type: string }
-  libraryID: { type: string }
+  templateID: { $ref: ../utils/uuid.schema.yaml }
+  libraryID: { $ref: ../utils/uuid.schema.yaml }

--- a/packages/file-format/schema/objects/prototype-viewport.schema.yaml
+++ b/packages/file-format/schema/objects/prototype-viewport.schema.yaml
@@ -1,5 +1,7 @@
 title: Prototype Viewport
-description: Defines a prototype viewport with a reference to the original template layer that was used defining it.
+description:
+  Defines a prototype viewport with a reference to the original template layer
+  that was used defining it.
 type: object
 optional:
   - templateID

--- a/packages/file-format/schema/objects/prototype-viewport.schema.yaml
+++ b/packages/file-format/schema/objects/prototype-viewport.schema.yaml
@@ -1,0 +1,12 @@
+title: Prototype Viewport
+description: Defines a prototype viewport with a reference to the original template layer that was used defining it.
+type: object
+optional:
+  - templateID
+  - libraryID
+properties:
+  _class: { const: MSImmutablePrototypeViewport }
+  name: { type: string }
+  size: { $ref: ../utils/size-string.schema.yaml }
+  templateID: { type: string }
+  libraryID: { type: string }

--- a/packages/file-format/schema/utils/size-string.schema.yaml
+++ b/packages/file-format/schema/utils/size-string.schema.yaml
@@ -1,0 +1,5 @@
+title: Size String
+description: |
+  A formatted string representation of a rectangle size, e.g. {10.5, 10}.
+type: string
+pattern: '^{-?\d+(.\d+)?(e-\d+)?, -?\d+(.\d+)?(e-\d+)?}$'

--- a/packages/file/src/__tests__/file.test.ts
+++ b/packages/file/src/__tests__/file.test.ts
@@ -24,6 +24,7 @@ describe('toFile', () => {
     isFlippedHorizontal: false,
     isFlippedVertical: false,
     isLocked: false,
+    isTemplate: false,
     isVisible: true,
     layerListExpandedType: 0,
     nameIsFixed: false,


### PR DESCRIPTION
- Add `isTemplate` attribute to Layer to mark it as template for insertion of copies elsewhere.
 - Artboards now contain a `prototypeViewport` attribute with a `PrototypeViewport` object to describe the associated viewport for prototypes, replacing the untyped presetDictionary attribute.
 - FlowConnection now contains an automatic destination option.