### PR TITLE
Add per-document library info

### DIFF
--- a/.changeset/popular-laws-fry.md
+++ b/.changeset/popular-laws-fry.md
@@ -1,0 +1,6 @@
+---
+'@sketch-hq/sketch-file-format': minor
+'@sketch-hq/sketch-file-format-ts': minor
+---
+
+Add per-document libraries info

--- a/packages/file-format/schema/abstract-document.schema.yaml
+++ b/packages/file-format/schema/abstract-document.schema.yaml
@@ -35,3 +35,6 @@ properties:
     items: { $ref: ./objects/font-ref.schema.yaml }
   documentState: { $ref: ./objects/document-state.schema.yaml }
   patchInfo: { $ref: ./objects/patch-info.schema.yaml }
+  perDocumentLibraries:
+    type: array
+    items: { $ref: ./objects/document-library-info.schema.yaml }

--- a/packages/file-format/schema/enums/document-library-type.schema.yaml
+++ b/packages/file-format/schema/enums/document-library-type.schema.yaml
@@ -1,0 +1,13 @@
+title: Document Library Type
+description:
+  Enumeration of the asset library type. Roughly represents all library types
+  from Preferences... > Libraries tab
+type: integer
+enum:
+  - 0
+  - 1
+  - 2
+enumDescriptions:
+  - Local
+  - Workspace
+  - Third-Party

--- a/packages/file-format/schema/objects/document-library-info.schema.yaml
+++ b/packages/file-format/schema/objects/document-library-info.schema.yaml
@@ -1,0 +1,18 @@
+title: Document Library Info
+description:
+  Represents a "reference" to the asset library, that is used in the document
+type: object
+optional:
+  - name
+  - appcastURL
+  - documentID
+  - shareID
+  - workspaceName
+properties:
+  _class: { const: MSImmutableDocumentLibraryInfo }
+  libraryType: { $ref: ../enums/document-library-type.schema.yaml }
+  name: { type: string }
+  appcastURL: { type: string }
+  documentID: { $ref: ./utils/uuid.schema.yaml }
+  shareID: { $ref: ./utils/uuid.schema.yaml }
+  workspaceName: { type: string }

--- a/packages/file/src/__tests__/file.test.ts
+++ b/packages/file/src/__tests__/file.test.ts
@@ -86,6 +86,7 @@ describe('toFile', () => {
         do_objectID: 'b08e8447-b31d-4901-abb7-8284e1f71113',
       },
       pages: [blankPage],
+      perDocumentLibraries: []
     },
     meta: {
       app: FileFormat.BundleId.Testing,


### PR DESCRIPTION
The changes introduce per-document libraries to the document model.

The gist of the changes is that now documents would have a more tangible "references" to libraries from which symbols come from. 
Mind that it's not libraries direct copies. Rather, it's just enough info to possibly restore libraries setup in another Sketch application. This simplifies communication between a document's authors and a document's consumers. Now consumers would know what libraries they need to install in order to work with a document