### PR TITLE
Add support for per-document libraries

### DIFF
--- a/.changeset/three-cycles-sleep.md
+++ b/.changeset/three-cycles-sleep.md
@@ -1,0 +1,6 @@
+---
+'@sketch-hq/sketch-file-format': minor
+'@sketch-hq/sketch-file-format-ts': minor
+---
+
+Add support for per-document libraries

--- a/packages/file-format/schema/meta.schema.yaml
+++ b/packages/file-format/schema/meta.schema.yaml
@@ -52,6 +52,7 @@ properties:
       - 143
       - 144
       - 145
+      - 146
   compatibilityVersion: { const: 99 }
   coeditCompatibilityVersion: { type: number }
   app: { $ref: ./enums/bundle-id.schema.yaml }

--- a/packages/file-format/schema/objects/document-library-info.schema.yaml
+++ b/packages/file-format/schema/objects/document-library-info.schema.yaml
@@ -3,6 +3,7 @@ description:
   Represents a "reference" to the asset library, that is used in the document
 type: object
 optional:
+  - do_objectID
   - name
   - appcastURL
   - documentID
@@ -10,6 +11,7 @@ optional:
   - workspaceName
 properties:
   _class: { const: MSImmutableDocumentLibraryInfo }
+  do_objectID: { $ref: ./utils/uuid.schema.yaml }
   libraryType: { $ref: ../enums/document-library-type.schema.yaml }
   name: { type: string }
   appcastURL: { type: string }


### PR DESCRIPTION
Adds `do_objectID` to library info and bumps the document version.